### PR TITLE
added start screen and nunchuk connection errors

### DIFF
--- a/lib/nunchuk_frogger.cpp
+++ b/lib/nunchuk_frogger.cpp
@@ -56,7 +56,11 @@ bool init_nunchuk(uint8_t address)
     Wire.write(0x00);
     Wire.endTransmission(true);
 
-    return calibrate(address);
+    if (!calibrate(address))
+    {
+        Wire.end();
+        return false;
+    } return true;
 }
 
 // Read the value of the Nunchuk
@@ -64,7 +68,7 @@ nunchuk_state get_nunchuk_state(uint8_t address)
 {
     // Check first to see if the Nunchuk is still connected and reset state if not
     if (!update_nunchuk_state(address))
-        state = {MIDDLE, MIDDLE, RELEASED, RELEASED};
+        state = {MIDDLE, MIDDLE, RELEASED, RELEASED, false};
 
     // Return the state
     return state;
@@ -79,7 +83,7 @@ inline bool update_nunchuk_state(uint8_t address, bool calibrate)
 {
     // Get the state from the provided address
     if (read(address, NCSTATE, STATELEN) != STATELEN)
-        return (false);
+        return false;
 
     uint8_t x_val = buffer[0];
     uint8_t y_val = buffer[1];
@@ -102,6 +106,8 @@ inline bool update_nunchuk_state(uint8_t address, bool calibrate)
     // Read the button values
     state.nunchuk_z = z_val == 1 ? PRESSED : RELEASED;
     state.nunchuk_c = c_val == 1 ? PRESSED : RELEASED;
+
+    state.connected = true;
 
     return true;
 }

--- a/lib/nunchuk_frogger.h
+++ b/lib/nunchuk_frogger.h
@@ -30,6 +30,7 @@ struct nunchuk_state
     nunchuk_joystick_state nunchuk_y;
     nunchuk_button_state nunchuk_z;
     nunchuk_button_state nunchuk_c;
+    bool connected;
 };
 
 // A function for initializing contact with the Nunchuk

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -38,6 +38,13 @@ enum eeprom_location
 	OPPONENT_HIGH_SCORE = EEAR0
 };
 
+enum nunchuk_screen
+{
+	START_UP,
+	START_SCREEN,
+	GAME_SCREEN
+};
+
 Player players[] = {
 	{{4 * 20, 15 * 20},
 	 {{4 * 20, 15 * 20},
@@ -115,16 +122,75 @@ void simulate_moveables()
 	simulate_single_log(&vec, 0, 10);
 }
 
+inline void black_screen()
+{
+	Vector2 screen_zero = {0, 0};
+	Vector2 screen_max = {SCREEN_WIDTH, SCREEN_HEIGHT / 10};
+	for (int i = 1; i <= 10; i++)
+	{
+		draw_rect(&screen_zero, &screen_max, text_color[0]);
+		screen_zero.y = screen_max.y;
+		screen_max.y = (SCREEN_HEIGHT / 10 * i);
+	}
+}
+
+void draw_start_screen();
+void nunchuk_disconnected(nunchuk_screen screen);
+
+inline void draw_start_screen()
+{
+	BasicImage logo = { {34, 75}, &image_croaker_logo };
+	black_screen();
+	draw_image(&logo);
+	draw_string({40, 220}, (char *) "Press C to start");
+	bool is_pressed = get_nunchuk_state(NUNCHUK_ADDRESS).nunchuk_c == PRESSED;
+	while(!is_pressed)
+	{
+		nunchuk_state nunchuk = get_nunchuk_state(NUNCHUK_ADDRESS);
+		if (!nunchuk.connected) nunchuk_disconnected(START_SCREEN);
+		is_pressed = nunchuk.nunchuk_c == PRESSED;
+	}
+}
+
+inline void nunchuk_disconnected(nunchuk_screen screen)
+{
+	black_screen();
+	switch (screen)
+	{
+		case START_UP:
+			draw_string({35, 150}, (char *) "ATTACH A NUNCHUK");
+			while (!init_nunchuk(NUNCHUK_ADDRESS)) { _delay_ms(100); }
+			break;
+		case START_SCREEN:
+			draw_string({35, 150}, (char *) "ATTACH A NUNCHUK");
+			while (!init_nunchuk(NUNCHUK_ADDRESS)) { _delay_ms(100); }
+			draw_start_screen();
+			break;
+		case GAME_SCREEN:
+			draw_string({55, 140}, (char *) "PLEASE RESET");
+			draw_string({15, 160}, (char *) "NUNCHUK DISCONNECTED");
+			while(true) {}
+			break;
+		default:
+			break;
+	}
+}
+
 int main(void)
 {
 	sei();
 
 	// Initialize required functionalities
-	setup_global_timer();
 	init_gfx();
-	init_ir(FREQ_VAL_56KHZ);
-	init_nunchuk(NUNCHUK_ADDRESS);
 
+	if (!init_nunchuk(NUNCHUK_ADDRESS))
+		nunchuk_disconnected(START_SCREEN);
+
+	draw_start_screen();
+
+	setup_global_timer();
+	init_ir(FREQ_VAL_56KHZ);
+	
 	// Draw the background & foreground
 	draw_tilemap(&background);
 	draw_tilemap(&foreground);
@@ -162,6 +228,7 @@ int main(void)
 	while (1)
 	{
 		nunchuk_state nunchuk = get_nunchuk_state(NUNCHUK_ADDRESS);
+		if(!nunchuk.connected) nunchuk_disconnected(GAME_SCREEN);
 		nunchuk_joystick_state y_val = nunchuk.nunchuk_y;
 		nunchuk_joystick_state x_val = nunchuk.nunchuk_x;
 


### PR DESCRIPTION
# Description of changes
<!-- Add in your changes, what type (feature, bugfix, documentation, etc) and the importance of everything here -->
+ A start screen with logo and text that says "press c to start"
+ A check in the Nunchuk state that displays whether it is still connected
+ A function that displays an error screen when the Nunchuk disconnects, with the possibility to continue if you are still on the start screen, else a reset is required
+ Some minor refactoring

# Reviewer(s)
<!-- Tag your reviewer(s) here -->
@jasperdej 

# Issue(s)
<!-- Use the Closes keyword to link your issues here -->
Closes #24

# Checks for the reviewer(s)
<!-- These checks must be resolved before merging this PR -->
- [x] All merge conflicts solved
- [x] All files checked and reviewed
- [x] All documentation updated
  - [x] Technisch ontwerp
  - [x] Functioneel ontwerp
